### PR TITLE
PASSWORD RESET

### DIFF
--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,1 +1,3 @@
-{}
+{
+  "test_user.py::UserTestCase::test_api_reset_password": true
+}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,3 +1,1 @@
-{
-  "test_user.py::UserTestCase": true
-}
+{}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,3 +1,1 @@
-{
-  "test_user.py::UserTestCase::test_api_reset_password": true
-}
+{}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,1 +1,3 @@
-{}
+{
+  "test_user.py::UserTestCase": true
+}

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -139,6 +139,14 @@ def create_app(config_name):
                 return response.status_code
 
 
+        else:
+            response=jsonify({"message":"enter all details","status_code":400})
+            response.status_code=400
+            return response
+            return response.status_code
+
+
+
                 
             
                     

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -124,6 +124,13 @@ def create_app(config_name):
                 response.status_code=200
                 return response
                 return response.status_code
+
+            elif response_message=="Password and confirm password must be the same":
+                response=jsonify({"message":"password and confirm must be the same","status_code":409})
+                response.status_code=409
+                return response
+                return response.status_code
+
                 
             
                     

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -107,7 +107,25 @@ def create_app(config_name):
         if session.get("username") is not None:
             session.pop("username", None)
             return jsonify({"message": "Logout successful"})
-        return jsonify({"message": "You are not logged in"})    
+        return jsonify({"message": "You are not logged in"})
+
+
+    @app.route('/api/v1/auth/reset-password', methods=['POST'])
+    def reset():
+        email=str(request.data.get('email', ''))
+        password=str(request.data.get('password', ''))
+        confirm_password=str(request.data.get('confirm_password', ''))
+
+        if email and password and confirm_password:
+            response_message=User.reset_password(email,password,confirm_password)
+
+            if response_message == "Password reset was successful":
+                response=jsonify({"message":"password reset successfully","status_code":200})
+                response.status_code=200
+                return response
+                return response.status_code
+                
+            
                     
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -131,6 +131,14 @@ def create_app(config_name):
                 return response
                 return response.status_code
 
+
+            elif response_message ==  "Account does not exist":
+                response=jsonify({"message":"password and confirm must be the same","status_code":404})
+                response.status_code=404
+                return response
+                return response.status_code
+
+
                 
             
                     

--- a/app/models.py
+++ b/app/models.py
@@ -144,7 +144,27 @@ class User(object):
         if len(password)<6:
             return True
 
-        return False               
+        return False
+
+    @staticmethod
+    def reset_password(email,password,confirm_password):
+        for user in User.user_list:
+            if user["email"] == email:
+                if password == confirm_password:
+                    user["password"]=password
+                    user["confirm_password"]=confirm_password
+                    message="Password reset was successful"
+                    return message
+
+                else:
+                    message="Password and confirm password must be the same"
+                    return message
+            else:
+                message="Account does not exist"
+                return message
+                        
+
+
 
 
         

--- a/test_user.py
+++ b/test_user.py
@@ -81,7 +81,7 @@ class UserTestCase(unittest.TestCase):
         result=self.client().post('/api/v1/auth/register', data=self.user)
         self.assertEqual(result.status_code,200)
 
-        res=self.client().post('/api/auth/reset-password', data=self.reset)
+        res=self.client().post('/api/v1/auth/reset-password', data=self.reset)
         self.assertEqual(res.status_code,200)
 
 

--- a/test_user.py
+++ b/test_user.py
@@ -97,6 +97,21 @@ class UserTestCase(unittest.TestCase):
 
 
 
+    def test_api_cannot_reset_account_that_does_not_exist(self):
+
+        """this will test if user can reset account that 
+        does not exist"""
+
+        result=self.client().post('/api/v1/auth/register', data=self.user)
+        self.assertEqual(result.status_code,200)
+
+        res=self.client().post('/api/v1/auth/reset-password', data={"email":"collinsnjau100@gmail.com","password":"987654","confirm_password":"987654"})
+        self.assertEqual(res.status_code,404)
+
+
+
+
+
 
 
 

--- a/test_user.py
+++ b/test_user.py
@@ -25,6 +25,8 @@ class UserTestCase(unittest.TestCase):
 
         self.login={"username":"collins","password":"123456"}
 
+        self.reset={"email":"collinsnjau39@gmail.com","password":"987654","confirm_password":"987654"}
+
 
 
     def test_api_can_create_user(self):
@@ -72,6 +74,16 @@ class UserTestCase(unittest.TestCase):
 
         res=self.client().post('/api/auth/register', data={"username":"njau","email":"collinsnjau40@gmail.com","password":"123","confirm_password":"123"})
         self.assertEqual(res.status_code,404)
+
+
+    def test_api_reset_password(self):
+        """this will test if user can reset password"""
+        result=self.client().post('/api/v1/auth/register', data=self.user)
+        self.assertEqual(result.status_code,200)
+
+        res=self.client().post('/api/auth/reset-password', data=self.reset)
+        self.assertEqual(res.status_code,200)
+
 
 
 

--- a/test_user.py
+++ b/test_user.py
@@ -84,6 +84,20 @@ class UserTestCase(unittest.TestCase):
         res=self.client().post('/api/v1/auth/reset-password', data=self.reset)
         self.assertEqual(res.status_code,200)
 
+    def test_api_cannot_reset_password_confirm_not_match(self):
+
+        """this will test if user can reset password
+        if password and confirm are not same"""
+
+        result=self.client().post('/api/v1/auth/register', data=self.user)
+        self.assertEqual(result.status_code,200)
+
+        res=self.client().post('/api/v1/auth/reset-password', data={"email":"collinsnjau39@gmail.com","password":"987654","confirm_password":"9876543"})
+        self.assertEqual(res.status_code,409)
+
+
+
+
 
 
 


### PR DESCRIPTION
#### What does this PR do? 
- Implements the reset password end point
   
#### Description of the PR
- A user can reset password on the /api/v1/auth/reset-password endpoint. The details to be supplied are the email, password and confirm password
   
#### How to manually test it
- Pytest

#### Link to pivotal tracker story
[##155953164](https://www.pivotaltracker.com/story/show/155953164)

#### Screenshots
screenshots to the UPDATE PASSWORD
![weconnect-reset](https://user-images.githubusercontent.com/23402614/37394445-d3e42762-2784-11e8-9512-b69c87cb5710.png)

screenshot to USING NEW PASSWORD
![weconnect-reset-success](https://user-images.githubusercontent.com/23402614/37394488-ed8fd94a-2784-11e8-98ae-85988618ac9a.png)

